### PR TITLE
Adding wrappers for owl (owlery) and cypher (pdb/neo4j) queries

### DIFF
--- a/src/vfb_connect/cross_server_tools.py
+++ b/src/vfb_connect/cross_server_tools.py
@@ -881,6 +881,20 @@ class VfbConnect:
             return self.terms(ids, verbose=verbose).get_summaries(return_dataframe=return_dataframe)
         return self.terms(ids, verbose=verbose)
 
+    def cypher_query(self, query, return_dataframe=True, verbose=False):
+        """
+        Run a Cypher query.
+
+        :param query: The Cypher query to run.
+        :param return_dataframe: Optional. Returns pandas DataFrame if `True`, otherwise returns list of dicts. Default `True`.
+        :return: A DataFrame or list of results.
+        :rtype: pandas.DataFrame or list of dicts
+        """
+        r = self.nc.commit_list([query])
+        dc = dict_cursor(r)
+        if return_dataframe:
+            return pd.DataFrame.from_records(dc)
+        return dc
 
     def term(self, term, verbose=False):
         """Get a VFBTerm object for a given term id, name, symbol or synonym.

--- a/src/vfb_connect/cross_server_tools.py
+++ b/src/vfb_connect/cross_server_tools.py
@@ -810,7 +810,76 @@ class VfbConnect:
         if return_dataframe:
             return pd.DataFrame.from_records(dc)
         return dc
-    
+
+    def owl_subclasses(self, query, query_by_label=True, return_id_only=False, return_dataframe=True, verbose=False):
+        """
+        Get subclasses of a given term.
+
+        Returns a VFBTerms of subclasses of the specified term.
+        If no data is found, returns False.
+
+        :param term: The ID, name, or symbol of a class in the Drosohila Anatomy Ontology (FBbt).
+        :param query_by_label: Optional. Query using cell type labels if `True`, or IDs if `False`. Default `True`.
+        :param return_id_only: Optional. Return only the subclass IDs if `True`. Default `False`.
+        :param return_dataframe: Optional. Returns pandas DataFrame if `True`, otherwise returns list of dicts. Default `True`.
+        :return: A DataFrame with subclasses of the specified term.
+        :rtype: dependant on the options a pandas.DataFrame, list of ids or VFBTerms. Default is VFBTerms
+        """
+        ids = self.oc.get_subclasses(query=query, query_by_label=query_by_label, verbose=verbose)
+        if not ids:
+            ids = []
+        if return_id_only:
+            return ids
+        if return_dataframe:
+            return self.terms(ids, verbose=verbose).get_summaries(return_dataframe=return_dataframe)
+        return self.terms(ids, verbose=verbose)
+
+
+    def owl_superclasses(self, query, query_by_label=True, return_id_only=False, return_dataframe=False, verbose=False):
+        """
+        Get superclasses of a given term.
+
+        Returns a VFBTerms of superclasses of the specified term.
+        If no data is found, returns False.
+
+        :param term: The ID, name, or symbol of a class in the Drosohila Anatomy Ontology (FBbt).
+        :param query_by_label: Optional. Query using cell type labels if `True`, or IDs if `False`. Default `True`.
+        :param return_id_only: Optional. Return only the superclass IDs if `True`. Default `False`.
+        :param return_dataframe: Optional. Returns pandas DataFrame if `True`, otherwise returns list of dicts. Default `True`.
+        :return: A DataFrame with superclasses of the specified term.
+       :rtype: dependant on the options a pandas.DataFrame, list of ids or VFBTerms. Default is VFBTerms
+        """
+        ids = self.oc.get_superclasses(query=query, query_by_label=query_by_label, verbose=verbose)
+        if not ids:
+            ids = []
+        if return_id_only:
+            return ids
+        if return_dataframe:
+            return self.terms(ids, verbose=verbose).get_summaries(return_dataframe=return_dataframe)
+        return self.terms(ids, verbose=verbose)
+
+    def owl_instances(self, query, query_by_label=True, return_id_only=False, return_dataframe=True, verbose=False):
+        """
+        Get instances of a given term.
+
+        Returns a VFBTerms of instances of the specified term.
+        If no data is found, returns False.
+
+        :param term: The ID, name, or symbol of a class in the Drosohila Anatomy Ontology (FBbt).
+        :param query_by_label: Optional. Query using cell type labels if `True`, or IDs if `False`. Default `True`.
+        :param return_id_only: Optional. Return only the instance IDs if `True`. Default `False`.
+        :param return_dataframe: Optional. Returns pandas DataFrame if `True`, otherwise returns list of dicts. Default `True`.
+        :return: A DataFrame with instances of the specified term.
+        :rtype: dependant on the options a pandas.DataFrame, list of ids or VFBTerms. Default is VFBTerms
+        """
+        ids = self.oc.get_instances(query=query, query_by_label=query_by_label, verbose=verbose)
+        if not ids:
+            ids = []
+        if return_id_only:
+            return ids
+        if return_dataframe:
+            return self.terms(ids, verbose=verbose).get_summaries(return_dataframe=return_dataframe)
+        return self.terms(ids, verbose=verbose)
 
 
     def term(self, term, verbose=False):

--- a/src/vfb_connect/schema/test/vfb_term_query_test.py
+++ b/src/vfb_connect/schema/test/vfb_term_query_test.py
@@ -42,7 +42,7 @@ class VfbTermTest(unittest.TestCase):
         self.assertGreater(len(expression), 5)
         print(expression[0].summary)
 
-    def test_scRNAseq_dataets(self):
+    def test_scRNAseq_datasets(self):
         cluster = self.vfb.term("FBlc0006144")
         datasets = cluster.datasets
         print(datasets)

--- a/src/vfb_connect/test/cross_server_tools_test.py
+++ b/src/vfb_connect/test/cross_server_tools_test.py
@@ -114,6 +114,13 @@ class VfbConnectTest(unittest.TestCase):
         self.assertTrue(ofb, "Query failed.")
         self.assertTrue(set(ofb) == set(ofbl))
 
+    def test_cypher_query(self):
+        fu = self.vc.cypher_query("MATCH (n:Class) WHERE n.label = 'fan-shaped body' RETURN n", return_dataframe=False)
+        self.assertTrue(fu)
+        self.assertTrue(len(fu) > 0)
+        self.assertTrue(isinstance(fu[0], dict))
+        self.assertEquals(fu[0]['n']['label'], 'fan-shaped body')
+
 class VfbTermTests(unittest.TestCase):
 
     def setUp(self):

--- a/src/vfb_connect/test/cross_server_tools_test.py
+++ b/src/vfb_connect/test/cross_server_tools_test.py
@@ -96,6 +96,24 @@ class VfbConnectTest(unittest.TestCase):
         term = vfb.term(test_key, verbose=True)
         self.assertEqual(term.id, "VFB_jrchk00a")
 
+    def test_get_owl_subclasses(self):
+        ofb = self.vc.owl_subclasses(query="RO:0002131 some FBbt:00003679", return_id_only=True)
+        self.assertTrue(ofb, "Query failed.")
+        self.assertGreater(len(ofb), 150,
+                           "Unexpectedly small number structures overlap FB")
+        ofbl = self.vc.owl_subclasses(query="'overlaps' some 'fan-shaped body'", query_by_label=True, return_id_only=True)
+        self.assertTrue(ofb, "Query failed.")
+        self.assertTrue(set(ofb) == set(ofbl))
+
+    def test_get_owl_instances(self):
+        ofb = self.vc.owl_instances(query="RO:0002131 some FBbt:00003679", return_id_only=True)
+        self.assertTrue(ofb, "Query failed.")
+        self.assertGreater(len(ofb), 150,
+                           "Unexpectedly small number structures overlap FB")
+        ofbl = self.vc.owl_instances(query="'overlaps' some 'fan-shaped body'", query_by_label=True, return_id_only=True)
+        self.assertTrue(ofb, "Query failed.")
+        self.assertTrue(set(ofb) == set(ofbl))
+
 class VfbTermTests(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
```
from vfb_connect import vfb

classes = vfb.owl_subclasses(query="'overlaps' some 'fan-shaped body'")

instances = vfb.owl_instances(query="'overlaps' some 'fan-shaped body'")
```
by default, this returns VFBTerms

```
class_dict = vfb.cypher_query("MATCH (n:Class) WHERE n.label = 'fan-shaped body' RETURN n", return_dataframe=False)
```
